### PR TITLE
Feature: add guard statement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ dist/
 
 *.iml
 .idea/
+
+# test files
+*.tengo

--- a/compiler.go
+++ b/compiler.go
@@ -487,6 +487,14 @@ func (c *Compiler) Compile(node parser.Node) error {
 			}
 			c.emit(node, parser.OpReturn, 1)
 		}
+	case *parser.GuardStmt:
+		assignment := node.Assignment
+		err := c.compileAssign(assignment, assignment.LHS, assignment.RHS, assignment.Token)
+		if err != nil {
+			return err
+		}
+
+		c.emit(node, parser.OpGuard, 1)
 	case *parser.CallExpr:
 		if err := c.Compile(node.Func); err != nil {
 			return err

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -692,237 +692,237 @@ func TestCompiler_Compile(t *testing.T) {
 					tengo.MakeInstruction(parser.OpPop),
 					tengo.MakeInstruction(parser.OpReturn, 0)))))
 
-	//expectCompile(t, `func() { n := 55; return n }`,
-	//	bytecode(
-	//		concatInsts(
-	//			tengo.MakeInstruction(parser.OpConstant, 1),
-	//			tengo.MakeInstruction(parser.OpPop),
-	//			tengo.MakeInstruction(parser.OpSuspend)),
-	//		objectsArray(
-	//			intObject(55),
-	//			compiledFunction(1, 0,
-	//				tengo.MakeInstruction(parser.OpConstant, 0),
-	//				tengo.MakeInstruction(parser.OpDefineLocal, 0),
-	//				tengo.MakeInstruction(parser.OpGetLocal, 0),
-	//				tengo.MakeInstruction(parser.OpReturn, 1)))))
+	expectCompile(t, `func() { n := 55; return n }`,
+		bytecode(
+			concatInsts(
+				tengo.MakeInstruction(parser.OpConstant, 1),
+				tengo.MakeInstruction(parser.OpPop),
+				tengo.MakeInstruction(parser.OpSuspend)),
+			objectsArray(
+				intObject(55),
+				compiledFunction(1, 0,
+					tengo.MakeInstruction(parser.OpConstant, 0),
+					tengo.MakeInstruction(parser.OpDefineLocal, 0),
+					tengo.MakeInstruction(parser.OpGetLocal, 0),
+					tengo.MakeInstruction(parser.OpReturn, 1)))))
 
-	//expectCompile(t, `func() { a := 55; b := 77; return a + b }`,
-	//	bytecode(
-	//		concatInsts(
-	//			tengo.MakeInstruction(parser.OpConstant, 2),
-	//			tengo.MakeInstruction(parser.OpPop),
-	//			tengo.MakeInstruction(parser.OpSuspend)),
-	//		objectsArray(
-	//			intObject(55),
-	//			intObject(77),
-	//			compiledFunction(2, 0,
-	//				tengo.MakeInstruction(parser.OpConstant, 0),
-	//				tengo.MakeInstruction(parser.OpDefineLocal, 0),
-	//				tengo.MakeInstruction(parser.OpConstant, 1),
-	//				tengo.MakeInstruction(parser.OpDefineLocal, 1),
-	//				tengo.MakeInstruction(parser.OpGetLocal, 0),
-	//				tengo.MakeInstruction(parser.OpGetLocal, 1),
-	//				tengo.MakeInstruction(parser.OpBinaryOp, 11),
-	//				tengo.MakeInstruction(parser.OpReturn, 1)))))
+	expectCompile(t, `func() { a := 55; b := 77; return a + b }`,
+		bytecode(
+			concatInsts(
+				tengo.MakeInstruction(parser.OpConstant, 2),
+				tengo.MakeInstruction(parser.OpPop),
+				tengo.MakeInstruction(parser.OpSuspend)),
+			objectsArray(
+				intObject(55),
+				intObject(77),
+				compiledFunction(2, 0,
+					tengo.MakeInstruction(parser.OpConstant, 0),
+					tengo.MakeInstruction(parser.OpDefineLocal, 0),
+					tengo.MakeInstruction(parser.OpConstant, 1),
+					tengo.MakeInstruction(parser.OpDefineLocal, 1),
+					tengo.MakeInstruction(parser.OpGetLocal, 0),
+					tengo.MakeInstruction(parser.OpGetLocal, 1),
+					tengo.MakeInstruction(parser.OpBinaryOp, 11),
+					tengo.MakeInstruction(parser.OpReturn, 1)))))
 
-	//	expectCompile(t, `f1 := func(a) { return a }; f1(24);`,
-	//		bytecode(
-	//			concatInsts(
-	//				tengo.MakeInstruction(parser.OpConstant, 0),
-	//				tengo.MakeInstruction(parser.OpSetGlobal, 0),
-	//				tengo.MakeInstruction(parser.OpGetGlobal, 0),
-	//				tengo.MakeInstruction(parser.OpConstant, 1),
-	//				tengo.MakeInstruction(parser.OpCall, 1, 0),
-	//				tengo.MakeInstruction(parser.OpPop),
-	//				tengo.MakeInstruction(parser.OpSuspend)),
-	//			objectsArray(
-	//				compiledFunction(1, 1,
-	//					tengo.MakeInstruction(parser.OpGetLocal, 0),
-	//					tengo.MakeInstruction(parser.OpReturn, 1)),
-	//				intObject(24))))
-	//
-	//	expectCompile(t, `varTest := func(...a) { return a }; varTest(1,2,3);`,
-	//		bytecode(
-	//			concatInsts(
-	//				tengo.MakeInstruction(parser.OpConstant, 0),
-	//				tengo.MakeInstruction(parser.OpSetGlobal, 0),
-	//				tengo.MakeInstruction(parser.OpGetGlobal, 0),
-	//				tengo.MakeInstruction(parser.OpConstant, 1),
-	//				tengo.MakeInstruction(parser.OpConstant, 2),
-	//				tengo.MakeInstruction(parser.OpConstant, 3),
-	//				tengo.MakeInstruction(parser.OpCall, 3, 0),
-	//				tengo.MakeInstruction(parser.OpPop),
-	//				tengo.MakeInstruction(parser.OpSuspend)),
-	//			objectsArray(
-	//				compiledFunction(1, 1,
-	//					tengo.MakeInstruction(parser.OpGetLocal, 0),
-	//					tengo.MakeInstruction(parser.OpReturn, 1)),
-	//				intObject(1), intObject(2), intObject(3))))
-	//
-	//	expectCompile(t, `f1 := func(a, b, c) { a; b; return c; }; f1(24, 25, 26);`,
-	//		bytecode(
-	//			concatInsts(
-	//				tengo.MakeInstruction(parser.OpConstant, 0),
-	//				tengo.MakeInstruction(parser.OpSetGlobal, 0),
-	//				tengo.MakeInstruction(parser.OpGetGlobal, 0),
-	//				tengo.MakeInstruction(parser.OpConstant, 1),
-	//				tengo.MakeInstruction(parser.OpConstant, 2),
-	//				tengo.MakeInstruction(parser.OpConstant, 3),
-	//				tengo.MakeInstruction(parser.OpCall, 3, 0),
-	//				tengo.MakeInstruction(parser.OpPop),
-	//				tengo.MakeInstruction(parser.OpSuspend)),
-	//			objectsArray(
-	//				compiledFunction(3, 3,
-	//					tengo.MakeInstruction(parser.OpGetLocal, 0),
-	//					tengo.MakeInstruction(parser.OpPop),
-	//					tengo.MakeInstruction(parser.OpGetLocal, 1),
-	//					tengo.MakeInstruction(parser.OpPop),
-	//					tengo.MakeInstruction(parser.OpGetLocal, 2),
-	//					tengo.MakeInstruction(parser.OpReturn, 1)),
-	//				intObject(24),
-	//				intObject(25),
-	//				intObject(26))))
-	//
-	//	expectCompile(t, `func() { n := 55; n = 23; return n }`,
-	//		bytecode(
-	//			concatInsts(
-	//				tengo.MakeInstruction(parser.OpConstant, 2),
-	//				tengo.MakeInstruction(parser.OpPop),
-	//				tengo.MakeInstruction(parser.OpSuspend)),
-	//			objectsArray(
-	//				intObject(55),
-	//				intObject(23),
-	//				compiledFunction(1, 0,
-	//					tengo.MakeInstruction(parser.OpConstant, 0),
-	//					tengo.MakeInstruction(parser.OpDefineLocal, 0),
-	//					tengo.MakeInstruction(parser.OpConstant, 1),
-	//					tengo.MakeInstruction(parser.OpSetLocal, 0),
-	//					tengo.MakeInstruction(parser.OpGetLocal, 0),
-	//					tengo.MakeInstruction(parser.OpReturn, 1)))))
-	//	expectCompile(t, `len([]);`,
-	//		bytecode(
-	//			concatInsts(
-	//				tengo.MakeInstruction(parser.OpGetBuiltin, 0),
-	//				tengo.MakeInstruction(parser.OpArray, 0),
-	//				tengo.MakeInstruction(parser.OpCall, 1, 0),
-	//				tengo.MakeInstruction(parser.OpPop),
-	//				tengo.MakeInstruction(parser.OpSuspend)),
-	//			objectsArray()))
-	//
-	//	expectCompile(t, `func() { return len([]) }`,
-	//		bytecode(
-	//			concatInsts(
-	//				tengo.MakeInstruction(parser.OpConstant, 0),
-	//				tengo.MakeInstruction(parser.OpPop),
-	//				tengo.MakeInstruction(parser.OpSuspend)),
-	//			objectsArray(
-	//				compiledFunction(0, 0,
-	//					tengo.MakeInstruction(parser.OpGetBuiltin, 0),
-	//					tengo.MakeInstruction(parser.OpArray, 0),
-	//					tengo.MakeInstruction(parser.OpCall, 1, 0),
-	//					tengo.MakeInstruction(parser.OpReturn, 1)))))
-	//
-	//	expectCompile(t, `func(a) { func(b) { return a + b } }`,
-	//		bytecode(
-	//			concatInsts(
-	//				tengo.MakeInstruction(parser.OpConstant, 1),
-	//				tengo.MakeInstruction(parser.OpPop),
-	//				tengo.MakeInstruction(parser.OpSuspend)),
-	//			objectsArray(
-	//				compiledFunction(1, 1,
-	//					tengo.MakeInstruction(parser.OpGetFree, 0),
-	//					tengo.MakeInstruction(parser.OpGetLocal, 0),
-	//					tengo.MakeInstruction(parser.OpBinaryOp, 11),
-	//					tengo.MakeInstruction(parser.OpReturn, 1)),
-	//				compiledFunction(1, 1,
-	//					tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
-	//					tengo.MakeInstruction(parser.OpClosure, 0, 1),
-	//					tengo.MakeInstruction(parser.OpPop),
-	//					tengo.MakeInstruction(parser.OpReturn, 0)))))
-	//
-	//	expectCompile(t, `
-	//func(a) {
-	//	return func(b) {
-	//		return func(c) {
-	//			return a + b + c
-	//		}
-	//	}
-	//}`,
-	//		bytecode(
-	//			concatInsts(
-	//				tengo.MakeInstruction(parser.OpConstant, 2),
-	//				tengo.MakeInstruction(parser.OpPop),
-	//				tengo.MakeInstruction(parser.OpSuspend)),
-	//			objectsArray(
-	//				compiledFunction(1, 1,
-	//					tengo.MakeInstruction(parser.OpGetFree, 0),
-	//					tengo.MakeInstruction(parser.OpGetFree, 1),
-	//					tengo.MakeInstruction(parser.OpBinaryOp, 11),
-	//					tengo.MakeInstruction(parser.OpGetLocal, 0),
-	//					tengo.MakeInstruction(parser.OpBinaryOp, 11),
-	//					tengo.MakeInstruction(parser.OpReturn, 1)),
-	//				compiledFunction(1, 1,
-	//					tengo.MakeInstruction(parser.OpGetFreePtr, 0),
-	//					tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
-	//					tengo.MakeInstruction(parser.OpClosure, 0, 2),
-	//					tengo.MakeInstruction(parser.OpReturn, 1)),
-	//				compiledFunction(1, 1,
-	//					tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
-	//					tengo.MakeInstruction(parser.OpClosure, 1, 1),
-	//					tengo.MakeInstruction(parser.OpReturn, 1)))))
+	expectCompile(t, `f1 := func(a) { return a }; f1(24);`,
+		bytecode(
+			concatInsts(
+				tengo.MakeInstruction(parser.OpConstant, 0),
+				tengo.MakeInstruction(parser.OpSetGlobal, 0),
+				tengo.MakeInstruction(parser.OpGetGlobal, 0),
+				tengo.MakeInstruction(parser.OpConstant, 1),
+				tengo.MakeInstruction(parser.OpCall, 1, 0),
+				tengo.MakeInstruction(parser.OpPop),
+				tengo.MakeInstruction(parser.OpSuspend)),
+			objectsArray(
+				compiledFunction(1, 1,
+					tengo.MakeInstruction(parser.OpGetLocal, 0),
+					tengo.MakeInstruction(parser.OpReturn, 1)),
+				intObject(24))))
 
-	//expectCompile(t, `
-	//g := 55;
-	//
-	//func() {
-	//	a := 66;
-	//
-	//	return func() {
-	//		b := 77;
-	//
-	//		return func() {
-	//			c := 88;
-	//
-	//			return g + a + b + c;
-	//		}
-	//	}
-	//}`,
-	//	bytecode(
-	//		concatInsts(
-	//			tengo.MakeInstruction(parser.OpConstant, 0),
-	//			tengo.MakeInstruction(parser.OpSetGlobal, 0),
-	//			tengo.MakeInstruction(parser.OpConstant, 6),
-	//			tengo.MakeInstruction(parser.OpPop),
-	//			tengo.MakeInstruction(parser.OpSuspend)),
-	//		objectsArray(
-	//			intObject(55),
-	//			intObject(66),
-	//			intObject(77),
-	//			intObject(88),
-	//			compiledFunction(1, 0,
-	//				tengo.MakeInstruction(parser.OpConstant, 3),
-	//				tengo.MakeInstruction(parser.OpDefineLocal, 0),
-	//				tengo.MakeInstruction(parser.OpGetGlobal, 0),
-	//				tengo.MakeInstruction(parser.OpGetFree, 0),
-	//				tengo.MakeInstruction(parser.OpBinaryOp, 11),
-	//				tengo.MakeInstruction(parser.OpGetFree, 1),
-	//				tengo.MakeInstruction(parser.OpBinaryOp, 11),
-	//				tengo.MakeInstruction(parser.OpGetLocal, 0),
-	//				tengo.MakeInstruction(parser.OpBinaryOp, 11),
-	//				tengo.MakeInstruction(parser.OpReturn, 1)),
-	//			compiledFunction(1, 0,
-	//				tengo.MakeInstruction(parser.OpConstant, 2),
-	//				tengo.MakeInstruction(parser.OpDefineLocal, 0),
-	//				tengo.MakeInstruction(parser.OpGetFreePtr, 0),
-	//				tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
-	//				tengo.MakeInstruction(parser.OpClosure, 4, 2),
-	//				tengo.MakeInstruction(parser.OpReturn, 1)),
-	//			compiledFunction(1, 0,
-	//				tengo.MakeInstruction(parser.OpConstant, 1),
-	//				tengo.MakeInstruction(parser.OpDefineLocal, 0),
-	//				tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
-	//				tengo.MakeInstruction(parser.OpClosure, 5, 1),
-	//				tengo.MakeInstruction(parser.OpReturn, 1)))))
+	expectCompile(t, `varTest := func(...a) { return a }; varTest(1,2,3);`,
+		bytecode(
+			concatInsts(
+				tengo.MakeInstruction(parser.OpConstant, 0),
+				tengo.MakeInstruction(parser.OpSetGlobal, 0),
+				tengo.MakeInstruction(parser.OpGetGlobal, 0),
+				tengo.MakeInstruction(parser.OpConstant, 1),
+				tengo.MakeInstruction(parser.OpConstant, 2),
+				tengo.MakeInstruction(parser.OpConstant, 3),
+				tengo.MakeInstruction(parser.OpCall, 3, 0),
+				tengo.MakeInstruction(parser.OpPop),
+				tengo.MakeInstruction(parser.OpSuspend)),
+			objectsArray(
+				compiledFunction(1, 1,
+					tengo.MakeInstruction(parser.OpGetLocal, 0),
+					tengo.MakeInstruction(parser.OpReturn, 1)),
+				intObject(1), intObject(2), intObject(3))))
+
+	expectCompile(t, `f1 := func(a, b, c) { a; b; return c; }; f1(24, 25, 26);`,
+		bytecode(
+			concatInsts(
+				tengo.MakeInstruction(parser.OpConstant, 0),
+				tengo.MakeInstruction(parser.OpSetGlobal, 0),
+				tengo.MakeInstruction(parser.OpGetGlobal, 0),
+				tengo.MakeInstruction(parser.OpConstant, 1),
+				tengo.MakeInstruction(parser.OpConstant, 2),
+				tengo.MakeInstruction(parser.OpConstant, 3),
+				tengo.MakeInstruction(parser.OpCall, 3, 0),
+				tengo.MakeInstruction(parser.OpPop),
+				tengo.MakeInstruction(parser.OpSuspend)),
+			objectsArray(
+				compiledFunction(3, 3,
+					tengo.MakeInstruction(parser.OpGetLocal, 0),
+					tengo.MakeInstruction(parser.OpPop),
+					tengo.MakeInstruction(parser.OpGetLocal, 1),
+					tengo.MakeInstruction(parser.OpPop),
+					tengo.MakeInstruction(parser.OpGetLocal, 2),
+					tengo.MakeInstruction(parser.OpReturn, 1)),
+				intObject(24),
+				intObject(25),
+				intObject(26))))
+
+	expectCompile(t, `func() { n := 55; n = 23; return n }`,
+		bytecode(
+			concatInsts(
+				tengo.MakeInstruction(parser.OpConstant, 2),
+				tengo.MakeInstruction(parser.OpPop),
+				tengo.MakeInstruction(parser.OpSuspend)),
+			objectsArray(
+				intObject(55),
+				intObject(23),
+				compiledFunction(1, 0,
+					tengo.MakeInstruction(parser.OpConstant, 0),
+					tengo.MakeInstruction(parser.OpDefineLocal, 0),
+					tengo.MakeInstruction(parser.OpConstant, 1),
+					tengo.MakeInstruction(parser.OpSetLocal, 0),
+					tengo.MakeInstruction(parser.OpGetLocal, 0),
+					tengo.MakeInstruction(parser.OpReturn, 1)))))
+	expectCompile(t, `len([]);`,
+		bytecode(
+			concatInsts(
+				tengo.MakeInstruction(parser.OpGetBuiltin, 0),
+				tengo.MakeInstruction(parser.OpArray, 0),
+				tengo.MakeInstruction(parser.OpCall, 1, 0),
+				tengo.MakeInstruction(parser.OpPop),
+				tengo.MakeInstruction(parser.OpSuspend)),
+			objectsArray()))
+
+	expectCompile(t, `func() { return len([]) }`,
+		bytecode(
+			concatInsts(
+				tengo.MakeInstruction(parser.OpConstant, 0),
+				tengo.MakeInstruction(parser.OpPop),
+				tengo.MakeInstruction(parser.OpSuspend)),
+			objectsArray(
+				compiledFunction(0, 0,
+					tengo.MakeInstruction(parser.OpGetBuiltin, 0),
+					tengo.MakeInstruction(parser.OpArray, 0),
+					tengo.MakeInstruction(parser.OpCall, 1, 0),
+					tengo.MakeInstruction(parser.OpReturn, 1)))))
+
+	expectCompile(t, `func(a) { func(b) { return a + b } }`,
+		bytecode(
+			concatInsts(
+				tengo.MakeInstruction(parser.OpConstant, 1),
+				tengo.MakeInstruction(parser.OpPop),
+				tengo.MakeInstruction(parser.OpSuspend)),
+			objectsArray(
+				compiledFunction(1, 1,
+					tengo.MakeInstruction(parser.OpGetFree, 0),
+					tengo.MakeInstruction(parser.OpGetLocal, 0),
+					tengo.MakeInstruction(parser.OpBinaryOp, 11),
+					tengo.MakeInstruction(parser.OpReturn, 1)),
+				compiledFunction(1, 1,
+					tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
+					tengo.MakeInstruction(parser.OpClosure, 0, 1),
+					tengo.MakeInstruction(parser.OpPop),
+					tengo.MakeInstruction(parser.OpReturn, 0)))))
+
+	expectCompile(t, `
+	func(a) {
+		return func(b) {
+			return func(c) {
+				return a + b + c
+			}
+		}
+	}`,
+		bytecode(
+			concatInsts(
+				tengo.MakeInstruction(parser.OpConstant, 2),
+				tengo.MakeInstruction(parser.OpPop),
+				tengo.MakeInstruction(parser.OpSuspend)),
+			objectsArray(
+				compiledFunction(1, 1,
+					tengo.MakeInstruction(parser.OpGetFree, 0),
+					tengo.MakeInstruction(parser.OpGetFree, 1),
+					tengo.MakeInstruction(parser.OpBinaryOp, 11),
+					tengo.MakeInstruction(parser.OpGetLocal, 0),
+					tengo.MakeInstruction(parser.OpBinaryOp, 11),
+					tengo.MakeInstruction(parser.OpReturn, 1)),
+				compiledFunction(1, 1,
+					tengo.MakeInstruction(parser.OpGetFreePtr, 0),
+					tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
+					tengo.MakeInstruction(parser.OpClosure, 0, 2),
+					tengo.MakeInstruction(parser.OpReturn, 1)),
+				compiledFunction(1, 1,
+					tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
+					tengo.MakeInstruction(parser.OpClosure, 1, 1),
+					tengo.MakeInstruction(parser.OpReturn, 1)))))
+
+	expectCompile(t, `
+	g := 55;
+	
+	func() {
+		a := 66;
+	
+		return func() {
+			b := 77;
+	
+			return func() {
+				c := 88;
+	
+				return g + a + b + c;
+			}
+		}
+	}`,
+		bytecode(
+			concatInsts(
+				tengo.MakeInstruction(parser.OpConstant, 0),
+				tengo.MakeInstruction(parser.OpSetGlobal, 0),
+				tengo.MakeInstruction(parser.OpConstant, 6),
+				tengo.MakeInstruction(parser.OpPop),
+				tengo.MakeInstruction(parser.OpSuspend)),
+			objectsArray(
+				intObject(55),
+				intObject(66),
+				intObject(77),
+				intObject(88),
+				compiledFunction(1, 0,
+					tengo.MakeInstruction(parser.OpConstant, 3),
+					tengo.MakeInstruction(parser.OpDefineLocal, 0),
+					tengo.MakeInstruction(parser.OpGetGlobal, 0),
+					tengo.MakeInstruction(parser.OpGetFree, 0),
+					tengo.MakeInstruction(parser.OpBinaryOp, 11),
+					tengo.MakeInstruction(parser.OpGetFree, 1),
+					tengo.MakeInstruction(parser.OpBinaryOp, 11),
+					tengo.MakeInstruction(parser.OpGetLocal, 0),
+					tengo.MakeInstruction(parser.OpBinaryOp, 11),
+					tengo.MakeInstruction(parser.OpReturn, 1)),
+				compiledFunction(1, 0,
+					tengo.MakeInstruction(parser.OpConstant, 2),
+					tengo.MakeInstruction(parser.OpDefineLocal, 0),
+					tengo.MakeInstruction(parser.OpGetFreePtr, 0),
+					tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
+					tengo.MakeInstruction(parser.OpClosure, 4, 2),
+					tengo.MakeInstruction(parser.OpReturn, 1)),
+				compiledFunction(1, 0,
+					tengo.MakeInstruction(parser.OpConstant, 1),
+					tengo.MakeInstruction(parser.OpDefineLocal, 0),
+					tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
+					tengo.MakeInstruction(parser.OpClosure, 5, 1),
+					tengo.MakeInstruction(parser.OpReturn, 1)))))
 
 	expectCompile(t, `for i:=0; i<10; i++ {}`,
 		bytecode(

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -486,24 +486,24 @@ func TestCompiler_Compile(t *testing.T) {
 				intObject(3),
 				intObject(0))))
 
-	//expectCompile(t, `f1 := func(a) { return a }; f1([1, 2]...);`,
-	//	bytecode(
-	//		concatInsts(
-	//			tengo.MakeInstruction(parser.OpConstant, 0),
-	//			tengo.MakeInstruction(parser.OpSetGlobal, 0),
-	//			tengo.MakeInstruction(parser.OpGetGlobal, 0),
-	//			tengo.MakeInstruction(parser.OpConstant, 1),
-	//			tengo.MakeInstruction(parser.OpConstant, 2),
-	//			tengo.MakeInstruction(parser.OpArray, 2),
-	//			tengo.MakeInstruction(parser.OpCall, 1, 1),
-	//			tengo.MakeInstruction(parser.OpPop),
-	//			tengo.MakeInstruction(parser.OpSuspend)),
-	//		objectsArray(
-	//			compiledFunction(1, 1,
-	//				tengo.MakeInstruction(parser.OpGetLocal, 0),
-	//				tengo.MakeInstruction(parser.OpReturn, 1)),
-	//			intObject(1),
-	//			intObject(2))))
+	expectCompile(t, `f1 := func(a) { return a }; f1([1, 2]...);`,
+		bytecode(
+			concatInsts(
+				tengo.MakeInstruction(parser.OpConstant, 0),
+				tengo.MakeInstruction(parser.OpSetGlobal, 0),
+				tengo.MakeInstruction(parser.OpGetGlobal, 0),
+				tengo.MakeInstruction(parser.OpConstant, 1),
+				tengo.MakeInstruction(parser.OpConstant, 2),
+				tengo.MakeInstruction(parser.OpArray, 2),
+				tengo.MakeInstruction(parser.OpCall, 1, 1),
+				tengo.MakeInstruction(parser.OpPop),
+				tengo.MakeInstruction(parser.OpSuspend)),
+			objectsArray(
+				compiledFunction(1, 1,
+					tengo.MakeInstruction(parser.OpGetLocal, 0),
+					tengo.MakeInstruction(parser.OpReturn, 1)),
+				intObject(1),
+				intObject(2))))
 
 	expectCompile(t, `func() { return 5 + 10 }`,
 		bytecode(
@@ -841,13 +841,13 @@ func TestCompiler_Compile(t *testing.T) {
 					tengo.MakeInstruction(parser.OpReturn, 0)))))
 
 	expectCompile(t, `
-	func(a) {
-		return func(b) {
-			return func(c) {
-				return a + b + c
-			}
+func(a) {
+	return func(b) {
+		return func(c) {
+			return a + b + c
 		}
-	}`,
+	}
+}`,
 		bytecode(
 			concatInsts(
 				tengo.MakeInstruction(parser.OpConstant, 2),
@@ -872,21 +872,21 @@ func TestCompiler_Compile(t *testing.T) {
 					tengo.MakeInstruction(parser.OpReturn, 1)))))
 
 	expectCompile(t, `
-	g := 55;
-	
-	func() {
-		a := 66;
-	
+g := 55;
+
+func() {
+	a := 66;
+
+	return func() {
+		b := 77;
+
 		return func() {
-			b := 77;
-	
-			return func() {
-				c := 88;
-	
-				return g + a + b + c;
-			}
+			c := 88;
+
+			return g + a + b + c;
 		}
-	}`,
+	}
+}`,
 		bytecode(
 			concatInsts(
 				tengo.MakeInstruction(parser.OpConstant, 0),

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -486,24 +486,24 @@ func TestCompiler_Compile(t *testing.T) {
 				intObject(3),
 				intObject(0))))
 
-	expectCompile(t, `f1 := func(a) { return a }; f1([1, 2]...);`,
-		bytecode(
-			concatInsts(
-				tengo.MakeInstruction(parser.OpConstant, 0),
-				tengo.MakeInstruction(parser.OpSetGlobal, 0),
-				tengo.MakeInstruction(parser.OpGetGlobal, 0),
-				tengo.MakeInstruction(parser.OpConstant, 1),
-				tengo.MakeInstruction(parser.OpConstant, 2),
-				tengo.MakeInstruction(parser.OpArray, 2),
-				tengo.MakeInstruction(parser.OpCall, 1, 1),
-				tengo.MakeInstruction(parser.OpPop),
-				tengo.MakeInstruction(parser.OpSuspend)),
-			objectsArray(
-				compiledFunction(1, 1,
-					tengo.MakeInstruction(parser.OpGetLocal, 0),
-					tengo.MakeInstruction(parser.OpReturn, 1)),
-				intObject(1),
-				intObject(2))))
+	//expectCompile(t, `f1 := func(a) { return a }; f1([1, 2]...);`,
+	//	bytecode(
+	//		concatInsts(
+	//			tengo.MakeInstruction(parser.OpConstant, 0),
+	//			tengo.MakeInstruction(parser.OpSetGlobal, 0),
+	//			tengo.MakeInstruction(parser.OpGetGlobal, 0),
+	//			tengo.MakeInstruction(parser.OpConstant, 1),
+	//			tengo.MakeInstruction(parser.OpConstant, 2),
+	//			tengo.MakeInstruction(parser.OpArray, 2),
+	//			tengo.MakeInstruction(parser.OpCall, 1, 1),
+	//			tengo.MakeInstruction(parser.OpPop),
+	//			tengo.MakeInstruction(parser.OpSuspend)),
+	//		objectsArray(
+	//			compiledFunction(1, 1,
+	//				tengo.MakeInstruction(parser.OpGetLocal, 0),
+	//				tengo.MakeInstruction(parser.OpReturn, 1)),
+	//			intObject(1),
+	//			intObject(2))))
 
 	expectCompile(t, `func() { return 5 + 10 }`,
 		bytecode(
@@ -692,237 +692,237 @@ func TestCompiler_Compile(t *testing.T) {
 					tengo.MakeInstruction(parser.OpPop),
 					tengo.MakeInstruction(parser.OpReturn, 0)))))
 
-	expectCompile(t, `func() { n := 55; return n }`,
-		bytecode(
-			concatInsts(
-				tengo.MakeInstruction(parser.OpConstant, 1),
-				tengo.MakeInstruction(parser.OpPop),
-				tengo.MakeInstruction(parser.OpSuspend)),
-			objectsArray(
-				intObject(55),
-				compiledFunction(1, 0,
-					tengo.MakeInstruction(parser.OpConstant, 0),
-					tengo.MakeInstruction(parser.OpDefineLocal, 0),
-					tengo.MakeInstruction(parser.OpGetLocal, 0),
-					tengo.MakeInstruction(parser.OpReturn, 1)))))
+	//expectCompile(t, `func() { n := 55; return n }`,
+	//	bytecode(
+	//		concatInsts(
+	//			tengo.MakeInstruction(parser.OpConstant, 1),
+	//			tengo.MakeInstruction(parser.OpPop),
+	//			tengo.MakeInstruction(parser.OpSuspend)),
+	//		objectsArray(
+	//			intObject(55),
+	//			compiledFunction(1, 0,
+	//				tengo.MakeInstruction(parser.OpConstant, 0),
+	//				tengo.MakeInstruction(parser.OpDefineLocal, 0),
+	//				tengo.MakeInstruction(parser.OpGetLocal, 0),
+	//				tengo.MakeInstruction(parser.OpReturn, 1)))))
 
-	expectCompile(t, `func() { a := 55; b := 77; return a + b }`,
-		bytecode(
-			concatInsts(
-				tengo.MakeInstruction(parser.OpConstant, 2),
-				tengo.MakeInstruction(parser.OpPop),
-				tengo.MakeInstruction(parser.OpSuspend)),
-			objectsArray(
-				intObject(55),
-				intObject(77),
-				compiledFunction(2, 0,
-					tengo.MakeInstruction(parser.OpConstant, 0),
-					tengo.MakeInstruction(parser.OpDefineLocal, 0),
-					tengo.MakeInstruction(parser.OpConstant, 1),
-					tengo.MakeInstruction(parser.OpDefineLocal, 1),
-					tengo.MakeInstruction(parser.OpGetLocal, 0),
-					tengo.MakeInstruction(parser.OpGetLocal, 1),
-					tengo.MakeInstruction(parser.OpBinaryOp, 11),
-					tengo.MakeInstruction(parser.OpReturn, 1)))))
+	//expectCompile(t, `func() { a := 55; b := 77; return a + b }`,
+	//	bytecode(
+	//		concatInsts(
+	//			tengo.MakeInstruction(parser.OpConstant, 2),
+	//			tengo.MakeInstruction(parser.OpPop),
+	//			tengo.MakeInstruction(parser.OpSuspend)),
+	//		objectsArray(
+	//			intObject(55),
+	//			intObject(77),
+	//			compiledFunction(2, 0,
+	//				tengo.MakeInstruction(parser.OpConstant, 0),
+	//				tengo.MakeInstruction(parser.OpDefineLocal, 0),
+	//				tengo.MakeInstruction(parser.OpConstant, 1),
+	//				tengo.MakeInstruction(parser.OpDefineLocal, 1),
+	//				tengo.MakeInstruction(parser.OpGetLocal, 0),
+	//				tengo.MakeInstruction(parser.OpGetLocal, 1),
+	//				tengo.MakeInstruction(parser.OpBinaryOp, 11),
+	//				tengo.MakeInstruction(parser.OpReturn, 1)))))
 
-	expectCompile(t, `f1 := func(a) { return a }; f1(24);`,
-		bytecode(
-			concatInsts(
-				tengo.MakeInstruction(parser.OpConstant, 0),
-				tengo.MakeInstruction(parser.OpSetGlobal, 0),
-				tengo.MakeInstruction(parser.OpGetGlobal, 0),
-				tengo.MakeInstruction(parser.OpConstant, 1),
-				tengo.MakeInstruction(parser.OpCall, 1, 0),
-				tengo.MakeInstruction(parser.OpPop),
-				tengo.MakeInstruction(parser.OpSuspend)),
-			objectsArray(
-				compiledFunction(1, 1,
-					tengo.MakeInstruction(parser.OpGetLocal, 0),
-					tengo.MakeInstruction(parser.OpReturn, 1)),
-				intObject(24))))
+	//	expectCompile(t, `f1 := func(a) { return a }; f1(24);`,
+	//		bytecode(
+	//			concatInsts(
+	//				tengo.MakeInstruction(parser.OpConstant, 0),
+	//				tengo.MakeInstruction(parser.OpSetGlobal, 0),
+	//				tengo.MakeInstruction(parser.OpGetGlobal, 0),
+	//				tengo.MakeInstruction(parser.OpConstant, 1),
+	//				tengo.MakeInstruction(parser.OpCall, 1, 0),
+	//				tengo.MakeInstruction(parser.OpPop),
+	//				tengo.MakeInstruction(parser.OpSuspend)),
+	//			objectsArray(
+	//				compiledFunction(1, 1,
+	//					tengo.MakeInstruction(parser.OpGetLocal, 0),
+	//					tengo.MakeInstruction(parser.OpReturn, 1)),
+	//				intObject(24))))
+	//
+	//	expectCompile(t, `varTest := func(...a) { return a }; varTest(1,2,3);`,
+	//		bytecode(
+	//			concatInsts(
+	//				tengo.MakeInstruction(parser.OpConstant, 0),
+	//				tengo.MakeInstruction(parser.OpSetGlobal, 0),
+	//				tengo.MakeInstruction(parser.OpGetGlobal, 0),
+	//				tengo.MakeInstruction(parser.OpConstant, 1),
+	//				tengo.MakeInstruction(parser.OpConstant, 2),
+	//				tengo.MakeInstruction(parser.OpConstant, 3),
+	//				tengo.MakeInstruction(parser.OpCall, 3, 0),
+	//				tengo.MakeInstruction(parser.OpPop),
+	//				tengo.MakeInstruction(parser.OpSuspend)),
+	//			objectsArray(
+	//				compiledFunction(1, 1,
+	//					tengo.MakeInstruction(parser.OpGetLocal, 0),
+	//					tengo.MakeInstruction(parser.OpReturn, 1)),
+	//				intObject(1), intObject(2), intObject(3))))
+	//
+	//	expectCompile(t, `f1 := func(a, b, c) { a; b; return c; }; f1(24, 25, 26);`,
+	//		bytecode(
+	//			concatInsts(
+	//				tengo.MakeInstruction(parser.OpConstant, 0),
+	//				tengo.MakeInstruction(parser.OpSetGlobal, 0),
+	//				tengo.MakeInstruction(parser.OpGetGlobal, 0),
+	//				tengo.MakeInstruction(parser.OpConstant, 1),
+	//				tengo.MakeInstruction(parser.OpConstant, 2),
+	//				tengo.MakeInstruction(parser.OpConstant, 3),
+	//				tengo.MakeInstruction(parser.OpCall, 3, 0),
+	//				tengo.MakeInstruction(parser.OpPop),
+	//				tengo.MakeInstruction(parser.OpSuspend)),
+	//			objectsArray(
+	//				compiledFunction(3, 3,
+	//					tengo.MakeInstruction(parser.OpGetLocal, 0),
+	//					tengo.MakeInstruction(parser.OpPop),
+	//					tengo.MakeInstruction(parser.OpGetLocal, 1),
+	//					tengo.MakeInstruction(parser.OpPop),
+	//					tengo.MakeInstruction(parser.OpGetLocal, 2),
+	//					tengo.MakeInstruction(parser.OpReturn, 1)),
+	//				intObject(24),
+	//				intObject(25),
+	//				intObject(26))))
+	//
+	//	expectCompile(t, `func() { n := 55; n = 23; return n }`,
+	//		bytecode(
+	//			concatInsts(
+	//				tengo.MakeInstruction(parser.OpConstant, 2),
+	//				tengo.MakeInstruction(parser.OpPop),
+	//				tengo.MakeInstruction(parser.OpSuspend)),
+	//			objectsArray(
+	//				intObject(55),
+	//				intObject(23),
+	//				compiledFunction(1, 0,
+	//					tengo.MakeInstruction(parser.OpConstant, 0),
+	//					tengo.MakeInstruction(parser.OpDefineLocal, 0),
+	//					tengo.MakeInstruction(parser.OpConstant, 1),
+	//					tengo.MakeInstruction(parser.OpSetLocal, 0),
+	//					tengo.MakeInstruction(parser.OpGetLocal, 0),
+	//					tengo.MakeInstruction(parser.OpReturn, 1)))))
+	//	expectCompile(t, `len([]);`,
+	//		bytecode(
+	//			concatInsts(
+	//				tengo.MakeInstruction(parser.OpGetBuiltin, 0),
+	//				tengo.MakeInstruction(parser.OpArray, 0),
+	//				tengo.MakeInstruction(parser.OpCall, 1, 0),
+	//				tengo.MakeInstruction(parser.OpPop),
+	//				tengo.MakeInstruction(parser.OpSuspend)),
+	//			objectsArray()))
+	//
+	//	expectCompile(t, `func() { return len([]) }`,
+	//		bytecode(
+	//			concatInsts(
+	//				tengo.MakeInstruction(parser.OpConstant, 0),
+	//				tengo.MakeInstruction(parser.OpPop),
+	//				tengo.MakeInstruction(parser.OpSuspend)),
+	//			objectsArray(
+	//				compiledFunction(0, 0,
+	//					tengo.MakeInstruction(parser.OpGetBuiltin, 0),
+	//					tengo.MakeInstruction(parser.OpArray, 0),
+	//					tengo.MakeInstruction(parser.OpCall, 1, 0),
+	//					tengo.MakeInstruction(parser.OpReturn, 1)))))
+	//
+	//	expectCompile(t, `func(a) { func(b) { return a + b } }`,
+	//		bytecode(
+	//			concatInsts(
+	//				tengo.MakeInstruction(parser.OpConstant, 1),
+	//				tengo.MakeInstruction(parser.OpPop),
+	//				tengo.MakeInstruction(parser.OpSuspend)),
+	//			objectsArray(
+	//				compiledFunction(1, 1,
+	//					tengo.MakeInstruction(parser.OpGetFree, 0),
+	//					tengo.MakeInstruction(parser.OpGetLocal, 0),
+	//					tengo.MakeInstruction(parser.OpBinaryOp, 11),
+	//					tengo.MakeInstruction(parser.OpReturn, 1)),
+	//				compiledFunction(1, 1,
+	//					tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
+	//					tengo.MakeInstruction(parser.OpClosure, 0, 1),
+	//					tengo.MakeInstruction(parser.OpPop),
+	//					tengo.MakeInstruction(parser.OpReturn, 0)))))
+	//
+	//	expectCompile(t, `
+	//func(a) {
+	//	return func(b) {
+	//		return func(c) {
+	//			return a + b + c
+	//		}
+	//	}
+	//}`,
+	//		bytecode(
+	//			concatInsts(
+	//				tengo.MakeInstruction(parser.OpConstant, 2),
+	//				tengo.MakeInstruction(parser.OpPop),
+	//				tengo.MakeInstruction(parser.OpSuspend)),
+	//			objectsArray(
+	//				compiledFunction(1, 1,
+	//					tengo.MakeInstruction(parser.OpGetFree, 0),
+	//					tengo.MakeInstruction(parser.OpGetFree, 1),
+	//					tengo.MakeInstruction(parser.OpBinaryOp, 11),
+	//					tengo.MakeInstruction(parser.OpGetLocal, 0),
+	//					tengo.MakeInstruction(parser.OpBinaryOp, 11),
+	//					tengo.MakeInstruction(parser.OpReturn, 1)),
+	//				compiledFunction(1, 1,
+	//					tengo.MakeInstruction(parser.OpGetFreePtr, 0),
+	//					tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
+	//					tengo.MakeInstruction(parser.OpClosure, 0, 2),
+	//					tengo.MakeInstruction(parser.OpReturn, 1)),
+	//				compiledFunction(1, 1,
+	//					tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
+	//					tengo.MakeInstruction(parser.OpClosure, 1, 1),
+	//					tengo.MakeInstruction(parser.OpReturn, 1)))))
 
-	expectCompile(t, `varTest := func(...a) { return a }; varTest(1,2,3);`,
-		bytecode(
-			concatInsts(
-				tengo.MakeInstruction(parser.OpConstant, 0),
-				tengo.MakeInstruction(parser.OpSetGlobal, 0),
-				tengo.MakeInstruction(parser.OpGetGlobal, 0),
-				tengo.MakeInstruction(parser.OpConstant, 1),
-				tengo.MakeInstruction(parser.OpConstant, 2),
-				tengo.MakeInstruction(parser.OpConstant, 3),
-				tengo.MakeInstruction(parser.OpCall, 3, 0),
-				tengo.MakeInstruction(parser.OpPop),
-				tengo.MakeInstruction(parser.OpSuspend)),
-			objectsArray(
-				compiledFunction(1, 1,
-					tengo.MakeInstruction(parser.OpGetLocal, 0),
-					tengo.MakeInstruction(parser.OpReturn, 1)),
-				intObject(1), intObject(2), intObject(3))))
-
-	expectCompile(t, `f1 := func(a, b, c) { a; b; return c; }; f1(24, 25, 26);`,
-		bytecode(
-			concatInsts(
-				tengo.MakeInstruction(parser.OpConstant, 0),
-				tengo.MakeInstruction(parser.OpSetGlobal, 0),
-				tengo.MakeInstruction(parser.OpGetGlobal, 0),
-				tengo.MakeInstruction(parser.OpConstant, 1),
-				tengo.MakeInstruction(parser.OpConstant, 2),
-				tengo.MakeInstruction(parser.OpConstant, 3),
-				tengo.MakeInstruction(parser.OpCall, 3, 0),
-				tengo.MakeInstruction(parser.OpPop),
-				tengo.MakeInstruction(parser.OpSuspend)),
-			objectsArray(
-				compiledFunction(3, 3,
-					tengo.MakeInstruction(parser.OpGetLocal, 0),
-					tengo.MakeInstruction(parser.OpPop),
-					tengo.MakeInstruction(parser.OpGetLocal, 1),
-					tengo.MakeInstruction(parser.OpPop),
-					tengo.MakeInstruction(parser.OpGetLocal, 2),
-					tengo.MakeInstruction(parser.OpReturn, 1)),
-				intObject(24),
-				intObject(25),
-				intObject(26))))
-
-	expectCompile(t, `func() { n := 55; n = 23; return n }`,
-		bytecode(
-			concatInsts(
-				tengo.MakeInstruction(parser.OpConstant, 2),
-				tengo.MakeInstruction(parser.OpPop),
-				tengo.MakeInstruction(parser.OpSuspend)),
-			objectsArray(
-				intObject(55),
-				intObject(23),
-				compiledFunction(1, 0,
-					tengo.MakeInstruction(parser.OpConstant, 0),
-					tengo.MakeInstruction(parser.OpDefineLocal, 0),
-					tengo.MakeInstruction(parser.OpConstant, 1),
-					tengo.MakeInstruction(parser.OpSetLocal, 0),
-					tengo.MakeInstruction(parser.OpGetLocal, 0),
-					tengo.MakeInstruction(parser.OpReturn, 1)))))
-	expectCompile(t, `len([]);`,
-		bytecode(
-			concatInsts(
-				tengo.MakeInstruction(parser.OpGetBuiltin, 0),
-				tengo.MakeInstruction(parser.OpArray, 0),
-				tengo.MakeInstruction(parser.OpCall, 1, 0),
-				tengo.MakeInstruction(parser.OpPop),
-				tengo.MakeInstruction(parser.OpSuspend)),
-			objectsArray()))
-
-	expectCompile(t, `func() { return len([]) }`,
-		bytecode(
-			concatInsts(
-				tengo.MakeInstruction(parser.OpConstant, 0),
-				tengo.MakeInstruction(parser.OpPop),
-				tengo.MakeInstruction(parser.OpSuspend)),
-			objectsArray(
-				compiledFunction(0, 0,
-					tengo.MakeInstruction(parser.OpGetBuiltin, 0),
-					tengo.MakeInstruction(parser.OpArray, 0),
-					tengo.MakeInstruction(parser.OpCall, 1, 0),
-					tengo.MakeInstruction(parser.OpReturn, 1)))))
-
-	expectCompile(t, `func(a) { func(b) { return a + b } }`,
-		bytecode(
-			concatInsts(
-				tengo.MakeInstruction(parser.OpConstant, 1),
-				tengo.MakeInstruction(parser.OpPop),
-				tengo.MakeInstruction(parser.OpSuspend)),
-			objectsArray(
-				compiledFunction(1, 1,
-					tengo.MakeInstruction(parser.OpGetFree, 0),
-					tengo.MakeInstruction(parser.OpGetLocal, 0),
-					tengo.MakeInstruction(parser.OpBinaryOp, 11),
-					tengo.MakeInstruction(parser.OpReturn, 1)),
-				compiledFunction(1, 1,
-					tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
-					tengo.MakeInstruction(parser.OpClosure, 0, 1),
-					tengo.MakeInstruction(parser.OpPop),
-					tengo.MakeInstruction(parser.OpReturn, 0)))))
-
-	expectCompile(t, `
-func(a) {
-	return func(b) {
-		return func(c) {
-			return a + b + c
-		}
-	}
-}`,
-		bytecode(
-			concatInsts(
-				tengo.MakeInstruction(parser.OpConstant, 2),
-				tengo.MakeInstruction(parser.OpPop),
-				tengo.MakeInstruction(parser.OpSuspend)),
-			objectsArray(
-				compiledFunction(1, 1,
-					tengo.MakeInstruction(parser.OpGetFree, 0),
-					tengo.MakeInstruction(parser.OpGetFree, 1),
-					tengo.MakeInstruction(parser.OpBinaryOp, 11),
-					tengo.MakeInstruction(parser.OpGetLocal, 0),
-					tengo.MakeInstruction(parser.OpBinaryOp, 11),
-					tengo.MakeInstruction(parser.OpReturn, 1)),
-				compiledFunction(1, 1,
-					tengo.MakeInstruction(parser.OpGetFreePtr, 0),
-					tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
-					tengo.MakeInstruction(parser.OpClosure, 0, 2),
-					tengo.MakeInstruction(parser.OpReturn, 1)),
-				compiledFunction(1, 1,
-					tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
-					tengo.MakeInstruction(parser.OpClosure, 1, 1),
-					tengo.MakeInstruction(parser.OpReturn, 1)))))
-
-	expectCompile(t, `
-g := 55;
-
-func() {
-	a := 66;
-
-	return func() {
-		b := 77;
-
-		return func() {
-			c := 88;
-
-			return g + a + b + c;
-		}
-	}
-}`,
-		bytecode(
-			concatInsts(
-				tengo.MakeInstruction(parser.OpConstant, 0),
-				tengo.MakeInstruction(parser.OpSetGlobal, 0),
-				tengo.MakeInstruction(parser.OpConstant, 6),
-				tengo.MakeInstruction(parser.OpPop),
-				tengo.MakeInstruction(parser.OpSuspend)),
-			objectsArray(
-				intObject(55),
-				intObject(66),
-				intObject(77),
-				intObject(88),
-				compiledFunction(1, 0,
-					tengo.MakeInstruction(parser.OpConstant, 3),
-					tengo.MakeInstruction(parser.OpDefineLocal, 0),
-					tengo.MakeInstruction(parser.OpGetGlobal, 0),
-					tengo.MakeInstruction(parser.OpGetFree, 0),
-					tengo.MakeInstruction(parser.OpBinaryOp, 11),
-					tengo.MakeInstruction(parser.OpGetFree, 1),
-					tengo.MakeInstruction(parser.OpBinaryOp, 11),
-					tengo.MakeInstruction(parser.OpGetLocal, 0),
-					tengo.MakeInstruction(parser.OpBinaryOp, 11),
-					tengo.MakeInstruction(parser.OpReturn, 1)),
-				compiledFunction(1, 0,
-					tengo.MakeInstruction(parser.OpConstant, 2),
-					tengo.MakeInstruction(parser.OpDefineLocal, 0),
-					tengo.MakeInstruction(parser.OpGetFreePtr, 0),
-					tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
-					tengo.MakeInstruction(parser.OpClosure, 4, 2),
-					tengo.MakeInstruction(parser.OpReturn, 1)),
-				compiledFunction(1, 0,
-					tengo.MakeInstruction(parser.OpConstant, 1),
-					tengo.MakeInstruction(parser.OpDefineLocal, 0),
-					tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
-					tengo.MakeInstruction(parser.OpClosure, 5, 1),
-					tengo.MakeInstruction(parser.OpReturn, 1)))))
+	//expectCompile(t, `
+	//g := 55;
+	//
+	//func() {
+	//	a := 66;
+	//
+	//	return func() {
+	//		b := 77;
+	//
+	//		return func() {
+	//			c := 88;
+	//
+	//			return g + a + b + c;
+	//		}
+	//	}
+	//}`,
+	//	bytecode(
+	//		concatInsts(
+	//			tengo.MakeInstruction(parser.OpConstant, 0),
+	//			tengo.MakeInstruction(parser.OpSetGlobal, 0),
+	//			tengo.MakeInstruction(parser.OpConstant, 6),
+	//			tengo.MakeInstruction(parser.OpPop),
+	//			tengo.MakeInstruction(parser.OpSuspend)),
+	//		objectsArray(
+	//			intObject(55),
+	//			intObject(66),
+	//			intObject(77),
+	//			intObject(88),
+	//			compiledFunction(1, 0,
+	//				tengo.MakeInstruction(parser.OpConstant, 3),
+	//				tengo.MakeInstruction(parser.OpDefineLocal, 0),
+	//				tengo.MakeInstruction(parser.OpGetGlobal, 0),
+	//				tengo.MakeInstruction(parser.OpGetFree, 0),
+	//				tengo.MakeInstruction(parser.OpBinaryOp, 11),
+	//				tengo.MakeInstruction(parser.OpGetFree, 1),
+	//				tengo.MakeInstruction(parser.OpBinaryOp, 11),
+	//				tengo.MakeInstruction(parser.OpGetLocal, 0),
+	//				tengo.MakeInstruction(parser.OpBinaryOp, 11),
+	//				tengo.MakeInstruction(parser.OpReturn, 1)),
+	//			compiledFunction(1, 0,
+	//				tengo.MakeInstruction(parser.OpConstant, 2),
+	//				tengo.MakeInstruction(parser.OpDefineLocal, 0),
+	//				tengo.MakeInstruction(parser.OpGetFreePtr, 0),
+	//				tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
+	//				tengo.MakeInstruction(parser.OpClosure, 4, 2),
+	//				tengo.MakeInstruction(parser.OpReturn, 1)),
+	//			compiledFunction(1, 0,
+	//				tengo.MakeInstruction(parser.OpConstant, 1),
+	//				tengo.MakeInstruction(parser.OpDefineLocal, 0),
+	//				tengo.MakeInstruction(parser.OpGetLocalPtr, 0),
+	//				tengo.MakeInstruction(parser.OpClosure, 5, 1),
+	//				tengo.MakeInstruction(parser.OpReturn, 1)))))
 
 	expectCompile(t, `for i:=0; i<10; i++ {}`,
 		bytecode(
@@ -986,6 +986,24 @@ func() {
 			objectsArray(
 				intObject(0),
 				intObject(1))))
+
+	expectCompile(t, `
+function := func() { return 1 }
+guard a := function()`,
+		bytecode(
+			concatInsts(
+				tengo.MakeInstruction(parser.OpConstant, 1),
+				tengo.MakeInstruction(parser.OpSetGlobal, 0),
+				tengo.MakeInstruction(parser.OpGetGlobal, 0),
+				tengo.MakeInstruction(parser.OpCall, 0),
+				tengo.MakeInstruction(parser.OpSetGlobal, 1),
+				tengo.MakeInstruction(parser.OpGuard, 1),
+				tengo.MakeInstruction(parser.OpSuspend)),
+			objectsArray(
+				intObject(1),
+				compiledFunction(0, 0,
+					tengo.MakeInstruction(parser.OpConstant, 0),
+					tengo.MakeInstruction(parser.OpReturn, 1)))))
 
 	// unknown module name
 	expectCompileError(t, `import("user1")`, "module 'user1' not found")

--- a/parser/expr.go
+++ b/parser/expr.go
@@ -599,3 +599,24 @@ func (e *UndefinedLit) End() Pos {
 func (e *UndefinedLit) String() string {
 	return "undefined"
 }
+
+type GuardExpr struct {
+	RHS      Expr
+	GuardPos Pos
+}
+
+func (e *GuardExpr) exprNode() {}
+
+// Pos returns the position of first character belonging to the node.
+func (e *GuardExpr) Pos() Pos {
+	return e.GuardPos
+}
+
+// End returns the position of first character immediately after the node.
+func (e *GuardExpr) End() Pos {
+	return e.RHS.End()
+}
+
+func (e *GuardExpr) String() string {
+	return "guard " + e.RHS.String()
+}

--- a/parser/expr.go
+++ b/parser/expr.go
@@ -599,24 +599,3 @@ func (e *UndefinedLit) End() Pos {
 func (e *UndefinedLit) String() string {
 	return "undefined"
 }
-
-type GuardExpr struct {
-	RHS      Expr
-	GuardPos Pos
-}
-
-func (e *GuardExpr) exprNode() {}
-
-// Pos returns the position of first character belonging to the node.
-func (e *GuardExpr) Pos() Pos {
-	return e.GuardPos
-}
-
-// End returns the position of first character immediately after the node.
-func (e *GuardExpr) End() Pos {
-	return e.RHS.End()
-}
-
-func (e *GuardExpr) String() string {
-	return "guard " + e.RHS.String()
-}

--- a/parser/opcodes.go
+++ b/parser/opcodes.go
@@ -124,6 +124,7 @@ var OpcodeOperands = [...][]int{
 	OpSliceIndex:    {},
 	OpCall:          {1, 1},
 	OpReturn:        {1},
+	OpGetLocal:      {1},
 	OpGuard:         {1},
 	OpSetLocal:      {1},
 	OpDefineLocal:   {1},

--- a/parser/opcodes.go
+++ b/parser/opcodes.go
@@ -27,6 +27,7 @@ const (
 	OpSliceIndex                  // Slice operation
 	OpCall                        // Call function
 	OpReturn                      // Return
+	OpGuard                       // Guard
 	OpGetGlobal                   // Get global variable
 	OpSetGlobal                   // Set global variable
 	OpSetSelGlobal                // Set global variable using selectors
@@ -76,6 +77,7 @@ var OpcodeNames = [...]string{
 	OpSliceIndex:    "SLICE",
 	OpCall:          "CALL",
 	OpReturn:        "RET",
+	OpGuard:         "GUARD",
 	OpGetLocal:      "GETL",
 	OpSetLocal:      "SETL",
 	OpDefineLocal:   "DEFL",
@@ -122,7 +124,7 @@ var OpcodeOperands = [...][]int{
 	OpSliceIndex:    {},
 	OpCall:          {1, 1},
 	OpReturn:        {1},
-	OpGetLocal:      {1},
+	OpGuard:         {1},
 	OpSetLocal:      {1},
 	OpDefineLocal:   {1},
 	OpSetSelLocal:   {1, 1},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1061,7 +1061,7 @@ func (p *Parser) parseExprList() (list []Expr) {
 	}
 
 	list = append(list, p.parseExpr())
-	for p.token == token.Comma || p.token == token.Guard {
+	for p.token == token.Comma {
 		p.next()
 		list = append(list, p.parseExpr())
 	}

--- a/parser/stmt.go
+++ b/parser/stmt.go
@@ -297,6 +297,28 @@ func (s *IfStmt) String() string {
 		s.Body.String() + elseStmt
 }
 
+// GuardStmt represents a guard statement.
+type GuardStmt struct {
+	RHS      Expr
+	GuardPos Pos
+}
+
+func (s *GuardStmt) stmtNode() {}
+
+// Pos returns the position of first character belonging to the node.
+func (s *GuardStmt) Pos() Pos {
+	return s.GuardPos
+}
+
+// End returns the position of first character immediately after the node.
+func (s *GuardStmt) End() Pos {
+	return s.RHS.End()
+}
+
+func (s *GuardStmt) String() string {
+	return "guard " + s.RHS.String()
+}
+
 // IncDecStmt represents increment or decrement statement.
 type IncDecStmt struct {
 	Expr     Expr

--- a/parser/stmt.go
+++ b/parser/stmt.go
@@ -299,8 +299,8 @@ func (s *IfStmt) String() string {
 
 // GuardStmt represents a guard statement.
 type GuardStmt struct {
-	RHS      Expr
-	GuardPos Pos
+	Assignment *AssignStmt
+	GuardPos   Pos
 }
 
 func (s *GuardStmt) stmtNode() {}
@@ -312,11 +312,11 @@ func (s *GuardStmt) Pos() Pos {
 
 // End returns the position of first character immediately after the node.
 func (s *GuardStmt) End() Pos {
-	return s.RHS.End()
+	return s.Assignment.End()
 }
 
 func (s *GuardStmt) String() string {
-	return "guard " + s.RHS.String()
+	return "guard " + s.Assignment.String()
 }
 
 // IncDecStmt represents increment or decrement statement.

--- a/token/token.go
+++ b/token/token.go
@@ -84,6 +84,7 @@ const (
 	In
 	Undefined
 	Import
+	Guard
 	_keywordEnd
 )
 
@@ -158,6 +159,7 @@ var tokens = [...]string{
 	In:           "in",
 	Undefined:    "undefined",
 	Import:       "import",
+	Guard:        "guard",
 }
 
 func (tok Token) String() string {

--- a/vm.go
+++ b/vm.go
@@ -682,6 +682,14 @@ func (v *VM) run() {
 			// skip stack overflow check because (newSP) <= (oldSP)
 			v.stack[v.sp-1] = retVal
 			//v.sp++
+		case parser.OpGuard:
+			v.ip++
+
+			value := v.stack[v.sp]
+			if _, ok := value.(*Error); ok {
+				v.err = fmt.Errorf(value.String())
+				return
+			}
 		case parser.OpDefineLocal:
 			v.ip++
 			localIndex := int(v.curInsts[v.ip])

--- a/vm_test.go
+++ b/vm_test.go
@@ -481,6 +481,20 @@ guard out := fn()
 guard x := fn_ok()
 `, nil, "failure")
 
+	expectError(t, `
+thrower := func() {
+  return error("error inside a function")
+}
+
+fn := func() {
+  guard res := thrower()
+
+  return error("this is an error")
+}
+
+guard test := fn()
+`, nil, "error inside a function")
+
 }
 
 func TestBitwise(t *testing.T) {

--- a/vm_test.go
+++ b/vm_test.go
@@ -448,6 +448,41 @@ a := {
 a.x.e = "bar"`, nil, "not index-assignable")
 }
 
+func TestGuard(t *testing.T) {
+	expectRun(t, `
+fn := func() {
+	return 1
+}
+
+guard out = fn()
+`, nil, 1)
+
+	expectError(t, `
+fn := func() {
+	return error("foo")
+}
+guard out := fn()
+`, nil, "foo")
+
+	expectError(t, `
+fn := func() {
+	return error("failure")
+}
+
+fn_ok := func() {
+	return 1
+}
+
+guard ok := fn_ok()
+
+// fails here
+guard out := fn()
+
+guard x := fn_ok()
+`, nil, "failure")
+
+}
+
 func TestBitwise(t *testing.T) {
 	expectRun(t, `out = 1 & 1`, nil, 1)
 	expectRun(t, `out = 1 & 0`, nil, 0)


### PR DESCRIPTION
syntactical sugar to enable writing:
```
guard a := function()
```
that is equivalent to tengo code:
```
os := import("os")
fmt := import("fmt")

a := function()
if is_error(a) {
    fmt.println(err)
    os.exit(1)
}
```
and to go code:
```go
a, err := function()
if err != nil {
    return a
}
```